### PR TITLE
add link to cargo doc document

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Rust crate for Tokyo Doves
 
 Write Description Here
+
+Visit [here](https://mat-der-d.github.io/tokyodoves/tokyodoves/) for auto generated documentation.


### PR DESCRIPTION
For convenience, the link to cargo doc document was added to Readme.md.