### PR TITLE
split implementations for BoardSet into BoardSet and RawBoardSet

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,7 +1,9 @@
 //! Convenient tools to analyze the game
 
-mod board_set;
+pub mod board_set;
 mod board_value;
 
-pub use board_set::*;
+pub use board_set::{
+    BoardSet, Difference, Drain, Intersection, IntoIter, Iter, SymmetricDifference, Union,
+};
 pub use board_value::*;


### PR DESCRIPTION
#41 の問題意識の解決のために整理。
`Board` 用のインターフェースとなる `BoardSet` と `u64` を生で扱う `RawBoardSet` に分離し、それぞれのメソッド名を自然なものにした。
さらに `Iter` 等の new メソッドを廃止することでマクロによる定義を見通し良くした。