### PR TITLE
Feature/#45 improve iter into iter

### DIFF
--- a/src/prelude/board/container.rs
+++ b/src/prelude/board/container.rs
@@ -37,7 +37,6 @@ impl<const N: usize> IntoIterator for FiniteActionContainer<N> {
     fn into_iter(self) -> Self::IntoIter {
         FiniteActionContainerIntoIter {
             iter: self.container.into_iter(),
-            item_count: 0,
         }
     }
 }
@@ -54,7 +53,6 @@ impl<'a, const N: usize> FiniteActionContainer<N> {
     pub fn iter(&'a self) -> FiniteActionContainerIter<'a> {
         FiniteActionContainerIter {
             iter: self.container.iter(),
-            item_count: 0,
         }
     }
 }
@@ -111,40 +109,26 @@ impl<const N: usize> ActionContainer for FiniteActionContainer<N> {
 /// An [`Iterator`] returned by [`FiniteActionContainer::iter`]
 pub struct FiniteActionContainerIter<'a> {
     iter: std::slice::Iter<'a, Option<Action>>,
-    item_count: usize,
 }
 
 impl<'a> Iterator for FiniteActionContainerIter<'a> {
     type Item = &'a Action;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.item_count >= self.iter.len() {
-            return None;
-        }
-
-        let item = self.iter.next()?.as_ref()?;
-        self.item_count += 1;
-        Some(item)
+        self.iter.next()?.as_ref()
     }
 }
 
 /// An [`Iterator`] returned by [`FiniteActionContainer::into_iter`]
 pub struct FiniteActionContainerIntoIter<const N: usize> {
     iter: std::array::IntoIter<Option<Action>, N>,
-    item_count: usize,
 }
 
 impl<const N: usize> Iterator for FiniteActionContainerIntoIter<N> {
     type Item = Action;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.item_count >= N {
-            return None;
-        }
-
-        let item = self.iter.next()??;
-        self.item_count += 1;
-        Some(item)
+        self.iter.next()?
     }
 }
 

--- a/src/prelude/board/container.rs
+++ b/src/prelude/board/container.rs
@@ -36,8 +36,8 @@ impl<const N: usize> IntoIterator for FiniteActionContainer<N> {
 
     fn into_iter(self) -> Self::IntoIter {
         FiniteActionContainerIntoIter {
-            container: self.container,
-            cursor: 0,
+            iter: self.container.into_iter(),
+            item_count: 0,
         }
     }
 }
@@ -132,23 +132,21 @@ impl<'a> Iterator for FiniteActionContainerIter<'a> {
 
 /// An [`Iterator`] returned by [`FiniteActionContainer::into_iter`]
 pub struct FiniteActionContainerIntoIter<const N: usize> {
-    container: [Option<Action>; N],
-    cursor: usize,
+    iter: std::array::IntoIter<Option<Action>, N>,
+    item_count: usize,
 }
 
 impl<const N: usize> Iterator for FiniteActionContainerIntoIter<N> {
     type Item = Action;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.cursor >= N {
+        if self.item_count >= N {
             return None;
         }
 
-        let item = self.container[self.cursor];
-        if item.is_some() {
-            self.cursor += 1;
-        }
-        item
+        let item = self.iter.next()??;
+        self.item_count += 1;
+        Some(item)
     }
 }
 

--- a/src/prelude/board/container.rs
+++ b/src/prelude/board/container.rs
@@ -53,8 +53,8 @@ impl<const N: usize> std::ops::Index<usize> for FiniteActionContainer<N> {
 impl<'a, const N: usize> FiniteActionContainer<N> {
     pub fn iter(&'a self) -> FiniteActionContainerIter<'a> {
         FiniteActionContainerIter {
-            container: &self.container,
-            cursor: 0,
+            iter: self.container.iter(),
+            item_count: 0,
         }
     }
 }
@@ -110,23 +110,21 @@ impl<const N: usize> ActionContainer for FiniteActionContainer<N> {
 
 /// An [`Iterator`] returned by [`FiniteActionContainer::iter`]
 pub struct FiniteActionContainerIter<'a> {
-    container: &'a [Option<Action>],
-    cursor: usize,
+    iter: std::slice::Iter<'a, Option<Action>>,
+    item_count: usize,
 }
 
 impl<'a> Iterator for FiniteActionContainerIter<'a> {
     type Item = &'a Action;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.cursor >= self.container.len() {
+        if self.item_count >= self.iter.len() {
             return None;
         }
 
-        let item = self.container[self.cursor].as_ref();
-        if item.is_some() {
-            self.cursor += 1;
-        }
-        item
+        let item = self.iter.next()?.as_ref()?;
+        self.item_count += 1;
+        Some(item)
     }
 }
 


### PR DESCRIPTION
issue #45 に対応する実装変更。
`.iter()` や `.into_iter()` で生成されるものを中に持つようにした結果、処理が速くなっただけではなく、実装自体もかなりシンプルになった。

以下はとあるベンチマークでの性能比較 (赤が従来、青が新しい実装)
Iter:
![image](https://github.com/mat-der-D/tokyodoves/assets/28098063/6343c225-b305-419c-bf26-2dc7b336019e)
IntoIter:
![image](https://github.com/mat-der-D/tokyodoves/assets/28098063/fece69b6-ab51-49dd-9ac2-bc64a5db708c)
