### PR TITLE
added some unsafe blocks

### DIFF
--- a/src/prelude/board.rs
+++ b/src/prelude/board.rs
@@ -1056,9 +1056,13 @@ impl Board {
                         continue;
                     };
 
+                    // safety is guaranteed because ih and iv ranges from 0 to 3
+                    // iv < 16 holds because field_idx above returns Some(0 ~ 15)
                     let ih = idx % 4;
                     let iv = idx / 4;
-                    matrix[iv][ih] = Some((c, d));
+                    unsafe {
+                        *matrix.get_unchecked_mut(iv).get_unchecked_mut(ih) = Some((c, d));
+                    }
                 }
             }
         }

--- a/src/prelude/board/canonicalizer.rs
+++ b/src/prelude/board/canonicalizer.rs
@@ -58,6 +58,8 @@ impl PositionMapper {
         if vsize == 0 || vsize >= 5 || hsize == 0 || hsize >= 5 {
             None
         } else {
+            // safety is guaranteed because (hsize - 1) + 4 * (vsize - 1) ranges from 0 to 15
+            // under the validation above
             let maps = unsafe { CONGRUENT_MAPS.get_unchecked((hsize - 1) + 4 * (vsize - 1)) };
             Some(Self { maps })
         }
@@ -67,6 +69,7 @@ impl PositionMapper {
         if index >= 8 || pos >= 16 {
             0
         } else {
+            // safety is guaranteed thanks to the validation above
             unsafe { *self.maps.get_unchecked(index).get_unchecked(pos) }
         }
     }

--- a/src/prelude/board/mask.rs
+++ b/src/prelude/board/mask.rs
@@ -677,12 +677,14 @@ impl MaskViewer {
     }
 
     pub fn view_mask(&self) -> &BitMask {
-        &MASKS[self.status]
+        // safety is guaranteed because self.status can be changed only via do_shift
+        unsafe { MASKS.get_unchecked(self.status) }
     }
 
     pub(super) fn view_next_mask(&self, d: Direction) -> &BitMask {
+        // safety is guaranteed because the turned value of Self::shift_status ranges from 0 to 63
         let next_status = Self::shift_status(self.status, d);
-        &MASKS[next_status]
+        unsafe { MASKS.get_unchecked(next_status) }
     }
 
     /// Get a (reference to) [`BitMask`] that contains `bit`

--- a/src/prelude/board/position.rs
+++ b/src/prelude/board/position.rs
@@ -16,13 +16,17 @@ impl DovePositions {
     }
 
     fn set_position(&mut self, dove: Dove, bit: u64) {
+        // safety is guaranteed because dove_to_index returns 0~5
         let i = dove_to_index(dove);
-        self.positions[i] = bit;
+        unsafe {
+            *self.positions.get_unchecked_mut(i) = bit;
+        }
     }
 
     fn position_of(&self, dove: Dove) -> &u64 {
+        // safety is guaranteed because dove_to_index returns 0~5
         let i = dove_to_index(dove);
-        &self.positions[i]
+        unsafe { self.positions.get_unchecked(i) }
     }
 
     fn union(&self) -> u64 {
@@ -31,9 +35,11 @@ impl DovePositions {
 
     fn union_except(&self, dove: Dove) -> u64 {
         let index = dove_to_index(dove);
-        (0..6)
-            .filter(|i| *i != index)
-            .fold(0, |union, i| union | self.positions[i])
+        self.positions
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != index)
+            .fold(0, |union, (_, pos)| union | *pos)
     }
 
     fn doves_in_hand(&self) -> DoveSet {
@@ -68,13 +74,15 @@ impl ColorDovePositions {
     }
 
     pub fn dove_positions(&self, color: Color) -> &DovePositions {
+        // safety is guaranteed because color_to_index return 0 or 1
         let i = color_to_index(color);
-        &self.positions[i]
+        unsafe { self.positions.get_unchecked(i) }
     }
 
     pub fn dove_positions_mut(&mut self, color: Color) -> &mut DovePositions {
+        // safety is guaranteed because color_to_index return 0 or 1
         let i = color_to_index(color);
-        &mut self.positions[i]
+        unsafe { self.positions.get_unchecked_mut(i) }
     }
 
     pub fn set_position(&mut self, color: Color, dove: Dove, bit: u64) {


### PR DESCRIPTION
インデックスアクセスのある部分にいくつか unsafe ブロックを導入してみた。
[i] の代わりに get_unchecked(i) (あるいは get_unchecked_mut(i)) を使うことで、境界値検査をスキップして高速化してくれないかな・・・という期待。
実際1%以下程度の高速化が見られた。