### PR TITLE
Implemented Agent trait and three examples; implemented arena

### DIFF
--- a/src/prelude/actions.rs
+++ b/src/prelude/actions.rs
@@ -225,7 +225,7 @@ impl Action {
                         let Some(pos) = board.position_in_rbcc(color, dove) else {
                             return Err(SSNDecodingError { error_type: DoveNotOnBoard(color, dove) });
                         };
-                        Ok(Action::Put(color, dove, -pos + shift))
+                        Ok(Action::Move(color, dove, -pos + shift))
                     }
                     Remove => Ok(Action::Remove(color, dove)),
                 }


### PR DESCRIPTION
#67 に関する対応。
- trait Agent を定義
- trait Agent を実装した struct を3種類実装 (RandomAgent, AnalistAgent, ConsoleAgent)
- Agent たちを戦わせる Arena を実装
- テスト実行で気づいたバグを修正