### PR TITLE
public BoardSet, RawBoardSet, Capacity

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -7,8 +7,6 @@ pub(crate) mod io;
 // By-pass export
 pub use crate::prelude::board::canonicalizer::PositionMapper;
 
-pub use board_set::{
-    BoardSet, Capacity, Difference, Drain, Intersection, IntoIter, Iter, SymmetricDifference, Union,
-};
+pub use board_set::{BoardSet, Capacity, RawBoardSet};
 pub use board_value::*;
 pub use io::*;


### PR DESCRIPTION
analysis 直下に export するものを BoardSet, RawBoardSet, Capacity に変更。
Iterator 群よりかは、直接オブジェクトとして取り扱いうるものたちを出しておいた方が賢明かなという判断。