### PR TITLE
hide internal implementation of Board

### DIFF
--- a/src/prelude/board/main.rs
+++ b/src/prelude/board/main.rs
@@ -147,10 +147,16 @@ pub enum SurroundedStatus {
 //  Implement Traits
 // *******************************************************************
 /// An implementation of Tokyo Doves board based on bitboard techniques
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Board {
     pub(crate) viewer: MaskViewer,
     pub(crate) positions: ColorDovePositions,
+}
+
+impl std::fmt::Debug for Board {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Board({:?})", self.to_simple_string(' ', ";"))
+    }
 }
 
 impl Board {


### PR DESCRIPTION
#120 への部分的対応。
`Board` の `Debug` で内部実装が見えないように変更。