### PR TITLE
Feature/debug iter

### DIFF
--- a/src/prelude/board/container.rs
+++ b/src/prelude/board/container.rs
@@ -150,6 +150,7 @@ impl<'a, const N: usize> IntoIterator for &'a FiniteActionContainer<N> {
 }
 
 /// An [`Iterator`] returned by [`FiniteActionContainer::iter`]
+#[derive(Clone)]
 pub(crate) struct FiniteActionContainerIter<'a> {
     iter: std::slice::Iter<'a, Option<Action>>,
 }
@@ -162,6 +163,7 @@ impl<'a> Iterator for FiniteActionContainerIter<'a> {
     }
 }
 
+#[derive(Clone)]
 /// An [`Iterator`] returned by [`FiniteActionContainer::into_iter`]
 pub(crate) struct FiniteActionContainerIntoIter<const N: usize> {
     iter: std::array::IntoIter<Option<Action>, N>,

--- a/src/prelude/board/container.rs
+++ b/src/prelude/board/container.rs
@@ -226,9 +226,17 @@ impl IntoIterator for DoveSet {
 }
 
 /// An owned [`Iterator`] returned by [`DoveSet::into_iter`]
+#[derive(Clone)]
 pub struct DoveSetIntoIter {
     dove_set: DoveSet,
     cursor: u8,
+}
+
+impl std::fmt::Debug for DoveSetIntoIter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vec: Vec<String> = self.clone().map(|d| format!("{d:?}")).collect();
+        write!(f, "DoveSetIntoIter[{}]", vec.join(", "))
+    }
 }
 
 impl DoveSetIntoIter {

--- a/src/prelude/board/main.rs
+++ b/src/prelude/board/main.rs
@@ -23,11 +23,25 @@ pub use crate::prelude::board::{
 // *******************************************************************
 /// Inherited implementation for capsuling
 macro_rules! impl_mutable_action_container {
-    ( $($target: ident { $internal: ty, $iter: ident, $into_iter: ident })* ) => {
+    ( $($target:ident { $internal:ty, $iter:ident, $iter_name:expr, $into_iter:ident, $into_iter_name:expr })* ) => {
         $(
             impl std::fmt::Debug for $target {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     write!(f, "{:?}", self.0)
+                }
+            }
+
+            impl<'a> std::fmt::Debug for $iter<'a> {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    let vec: Vec<String> = self.0.clone().map(|a| format!("{a:?}")).collect();
+                    write!(f, "{}([{}])", $iter_name, vec.join(", "))
+                }
+            }
+
+            impl std::fmt::Debug for $into_iter {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    let vec: Vec<String> = self.0.clone().map(|a| format!("{a:?}")).collect();
+                    write!(f, "{}([{}])", $into_iter_name, vec.join(", "))
                 }
             }
 
@@ -114,9 +128,11 @@ macro_rules! impl_mutable_action_container {
 pub struct ActionsFwd(FiniteActionContainer<64>);
 
 /// An [`Iterator`] returned by [`ActionsFwd::iter`]
+#[derive(Clone)]
 pub struct ActionsFwdIter<'a>(FiniteActionContainerIter<'a>);
 
 /// An [`Iterator`] returned by [`ActionsFwd::into_iter`]
+#[derive(Clone)]
 pub struct ActionsFwdIntoIter(FiniteActionContainerIntoIter<64>);
 
 /// An [`ActionContainer`] returned by [`Board::legal_actions_bwd`].
@@ -125,14 +141,24 @@ pub struct ActionsFwdIntoIter(FiniteActionContainerIntoIter<64>);
 pub struct ActionsBwd(FiniteActionContainer<100>);
 
 /// An [`Iterator`] returned by [`ActionsBwd::iter`]
+#[derive(Clone)]
 pub struct ActionsBwdIter<'a>(FiniteActionContainerIter<'a>);
 
 /// An [`Iterator`] returned by [`ActionsBwd::into_iter`]
+#[derive(Clone)]
 pub struct ActionsBwdIntoIter(FiniteActionContainerIntoIter<100>);
 
 impl_mutable_action_container! {
-    ActionsFwd { FiniteActionContainer<64>, ActionsFwdIter, ActionsFwdIntoIter }
-    ActionsBwd { FiniteActionContainer<100>, ActionsBwdIter, ActionsBwdIntoIter }
+    ActionsFwd {
+        FiniteActionContainer<64>,
+        ActionsFwdIter, "ActionsFwdIter",
+        ActionsFwdIntoIter, "ActionsFwdIntoIter"
+    }
+    ActionsBwd {
+        FiniteActionContainer<100>,
+        ActionsBwdIter, "ActionsBwdIter",
+        ActionsBwdIntoIter, "ActionsBwdIntoIter"
+    }
 }
 
 /// An enum returned by [`Board::surrounded_status`]


### PR DESCRIPTION
#120 の部分的対応。
- `ActionsFwd`, `ActionsBwd` それぞれの iter, into_iter の返り値に `Debug` を実装。
- `DoveSet` の `IntoIterator` の返り値 `DoveSetIntoIterator` に `Debug` を実装。