### PR TITLE
implemented sealed debug for Iterators of BoardSet

### DIFF
--- a/src/prelude/board/container.rs
+++ b/src/prelude/board/container.rs
@@ -44,14 +44,7 @@ pub(crate) struct FiniteActionContainer<const N: usize> {
 
 impl<const N: usize> std::fmt::Debug for FiniteActionContainer<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.iter()
-                .map(|x| format!("{x:?}"))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 
@@ -190,14 +183,7 @@ pub struct DoveSet {
 
 impl std::fmt::Debug for DoveSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.into_iter()
-                .map(|d| format!("{d:?}"))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
+        f.debug_set().entries(self.into_iter()).finish()
     }
 }
 
@@ -238,8 +224,8 @@ pub struct DoveSetIntoIter {
 
 impl std::fmt::Debug for DoveSetIntoIter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let vec: Vec<String> = self.clone().map(|d| format!("{d:?}")).collect();
-        write!(f, "DoveSetIntoIter[{}]", vec.join(", "))
+        let vec: Vec<Dove> = self.clone().collect();
+        f.debug_tuple("DoveSetIntoIter").field(&vec).finish()
     }
 }
 

--- a/src/prelude/board/main.rs
+++ b/src/prelude/board/main.rs
@@ -33,15 +33,15 @@ macro_rules! impl_mutable_action_container {
 
             impl<'a> std::fmt::Debug for $iter<'a> {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    let vec: Vec<String> = self.0.clone().map(|a| format!("{a:?}")).collect();
-                    write!(f, "{}([{}])", $iter_name, vec.join(", "))
+                    let vec: Vec<&Action> = self.0.clone().collect();
+                    f.debug_tuple($iter_name).field(&vec).finish()
                 }
             }
 
             impl std::fmt::Debug for $into_iter {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    let vec: Vec<String> = self.0.clone().map(|a| format!("{a:?}")).collect();
-                    write!(f, "{}([{}])", $into_iter_name, vec.join(", "))
+                    let vec: Vec<Action> = self.0.clone().collect();
+                    f.debug_tuple($into_iter_name).field(&vec).finish()
                 }
             }
 


### PR DESCRIPTION
#120 への対応。
- `BoardSet` については、Clone が derive できるものについては他と同様の定義を採用。無理なものは要素を [..] の形で隠ぺい。
- f.debug_tuple をフル活用。