### PR TITLE
Release v0.1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokyodoves"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Smooth Pudding <smooth.pudding.1017@gmail.com>"]
 edition = "2021"
 

--- a/src/collections/board_set.rs
+++ b/src/collections/board_set.rs
@@ -838,6 +838,11 @@ impl BoardSet {
     {
         self.raw.save(writer)
     }
+
+    pub fn split(self, left_len: usize) -> (Self, Self) {
+        let (left_raw, right_raw) = self.into_raw().split(left_len);
+        (left_raw.into(), right_raw.into())
+    }
 }
 
 impl std::ops::BitAnd<&BoardSet> for &BoardSet {
@@ -1889,6 +1894,37 @@ impl RawBoardSet {
         writer.flush()?;
         Ok(())
     }
+
+    pub fn split(self, len_left: usize) -> (Self, Self) {
+        let mut left = RawBoardSet::new();
+        let mut right = RawBoardSet::new();
+
+        let mut add_to_left = true;
+        let mut len_left_tmp = 0;
+        for (top, bottoms) in self.top2bottoms {
+            if !add_to_left {
+                right.top2bottoms.insert(top, bottoms);
+                continue;
+            }
+
+            let residual = len_left - len_left_tmp;
+            if bottoms.len() <= residual {
+                len_left_tmp += bottoms.len();
+                left.top2bottoms.insert(top, bottoms);
+            } else {
+                let mut bottoms_iter = bottoms.into_iter();
+                let left_bottoms = (&mut bottoms_iter).take(residual).collect();
+                let right_bottoms = bottoms_iter.collect();
+                left.top2bottoms.insert(top, left_bottoms);
+                right.top2bottoms.insert(top, right_bottoms);
+            }
+
+            if len_left_tmp == len_left {
+                add_to_left = false;
+            }
+        }
+        (left, right)
+    }
 }
 
 impl std::ops::BitAnd<&RawBoardSet> for &RawBoardSet {
@@ -2417,5 +2453,40 @@ mod tests {
         }
         assert!(set.is_empty());
         assert_eq!(capacity, set.capacity());
+    }
+
+    #[test]
+    fn test_split() {
+        let set = create_from_strs(&["Bb", "Bbh", "Bba"]);
+
+        let (left, right) = set.clone().split(0);
+        assert_eq!(left.len(), 0);
+        assert_eq!(right.len(), 3);
+        assert_eq!(&left | &right, set);
+
+        let (left, right) = set.clone().split(1);
+        assert_eq!(left.len(), 1);
+        assert_eq!(right.len(), 2);
+        assert_eq!(&left | &right, set);
+
+        let (left, right) = set.clone().split(10);
+        assert_eq!(left.len(), 3);
+        assert_eq!(&left | &right, set);
+
+        let set = set.into_raw();
+
+        let (left, right) = set.clone().split(0);
+        assert_eq!(left.len(), 0);
+        assert_eq!(right.len(), 3);
+        assert_eq!(&left | &right, set);
+
+        let (left, right) = set.clone().split(1);
+        assert_eq!(left.len(), 1);
+        assert_eq!(right.len(), 2);
+        assert_eq!(&left | &right, set);
+
+        let (left, right) = set.clone().split(10);
+        assert_eq!(left.len(), 3);
+        assert_eq!(&left | &right, set);
     }
 }

--- a/src/collections/board_set.rs
+++ b/src/collections/board_set.rs
@@ -1284,7 +1284,7 @@ impl RawBoardSet {
     /// ```
     pub fn new_from_file(path: impl AsRef<std::path::Path>) -> std::io::Result<RawBoardSet> {
         let capacity = Self::required_capacity(std::fs::File::open(&path)?);
-        let mut set = RawBoardSet::with_capacity(capacity);
+        let mut set = Self::with_capacity(capacity);
         set.load(std::fs::File::open(path)?)?;
         Ok(set)
     }

--- a/src/collections/board_set.rs
+++ b/src/collections/board_set.rs
@@ -255,7 +255,7 @@ impl BoardSet {
         Self::default()
     }
 
-    /// Creates an `RawBoardSet` by loading a file.
+    /// Creates an `BoardSet` by loading a file.
     ///
     /// # Examples
     /// ``` ignore

--- a/src/collections/board_set.rs
+++ b/src/collections/board_set.rs
@@ -839,6 +839,28 @@ impl BoardSet {
         self.raw.save(writer)
     }
 
+    /// Splits the set into two sets.
+    ///
+    /// The argument `left_len` indicates the length of the left component
+    /// of the returned value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use std::str::FromStr;
+    /// use tokyodoves::{Board, BoardBuilder};
+    /// use tokyodoves::collections::BoardSet;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut set = BoardSet::new();
+    /// set.insert(Board::new());
+    /// set.insert(BoardBuilder::from_str("BbH")?.build()?);
+    /// set.insert(BoardBuilder::from_str("BbA")?.build()?);
+    /// let (left, right) = set.split(2);
+    /// assert_eq!(left.len(), 2);
+    /// assert_eq!(right.len(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn split(self, left_len: usize) -> (Self, Self) {
         let (left_raw, right_raw) = self.into_raw().split(left_len);
         (left_raw.into(), right_raw.into())
@@ -1895,6 +1917,28 @@ impl RawBoardSet {
         Ok(())
     }
 
+    /// Splits the set into two sets.
+    ///
+    /// The argument `left_len` indicates the length of the left component
+    /// of the returned value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use std::str::FromStr;
+    /// use tokyodoves::{Board, BoardBuilder};
+    /// use tokyodoves::collections::board_set::RawBoardSet;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut set = RawBoardSet::new();
+    /// set.insert(Board::new().to_u64());
+    /// set.insert(BoardBuilder::from_str("BbH")?.build()?.to_u64());
+    /// set.insert(BoardBuilder::from_str("BbA")?.build()?.to_u64());
+    /// let (left, right) = set.split(2);
+    /// assert_eq!(left.len(), 2);
+    /// assert_eq!(right.len(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn split(self, len_left: usize) -> (Self, Self) {
         let mut left = RawBoardSet::new();
         let mut right = RawBoardSet::new();

--- a/src/collections/board_set.rs
+++ b/src/collections/board_set.rs
@@ -255,6 +255,24 @@ impl BoardSet {
         Self::default()
     }
 
+    /// Creates an `RawBoardSet` by loading a file.
+    ///
+    /// # Examples
+    /// ``` ignore
+    /// use std::fs::File;
+    /// use tokyodoves::collections::BoardSet;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let path = "/some/path/of/binary/file.tdl";
+    /// let set = BoardSet::new_from_file(path)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_from_file(path: impl AsRef<std::path::Path>) -> std::io::Result<BoardSet> {
+        let raw_set = RawBoardSet::new_from_file(path)?;
+        Ok(raw_set.into())
+    }
+
     /// Returns a reference to the internal [`RawBoardSet`].
     ///
     /// # Examples
@@ -1240,7 +1258,7 @@ impl<'a> IntoIterator for &'a RawBoardSet {
 }
 
 impl RawBoardSet {
-    /// Creates an empty `BoardSet`.
+    /// Creates an empty `RawBoardSet`.
     ///
     /// # Examples
     /// ```rust
@@ -1249,6 +1267,26 @@ impl RawBoardSet {
     /// ```
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates an `RawBoardSet` by loading a file.
+    ///
+    /// # Examples
+    /// ``` ignore
+    /// use std::fs::File;
+    /// use tokyodoves::collections::board_set::RawBoardSet;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let path = "/some/path/of/binary/file.tdl";
+    /// let set = RawBoardSet::new_from_file(path)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_from_file(path: impl AsRef<std::path::Path>) -> std::io::Result<RawBoardSet> {
+        let capacity = Self::required_capacity(std::fs::File::open(&path)?);
+        let mut set = RawBoardSet::with_capacity(capacity);
+        set.load(std::fs::File::open(path)?)?;
+        Ok(set)
     }
 
     /// Returns [`Capacity`] required to load all elements specified by `reader`.


### PR DESCRIPTION
Updates:
`BoardSet` and `RawBoardSet` acquired new methods `split` and `new_from_file`. See the documentation for their usages or other information.